### PR TITLE
feat: setup projects cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 log/
 logs/
 .vscode/
+
+### Projects cache ###
+.projects.yaml

--- a/internal/cache/projects.go
+++ b/internal/cache/projects.go
@@ -1,0 +1,116 @@
+package cache
+
+import (
+	"copycat/internal/config"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type cachedProject struct {
+	Repo           string `yaml:"repo"`
+	SlackRoom      string `yaml:"slack_room"`
+	RequiresTicket bool   `yaml:"requires_ticket"`
+}
+
+type projectCache struct {
+	Projects []cachedProject `yaml:"projects"`
+}
+
+// LoadProjects reads cached projects from disk.
+func LoadProjects(filename string) ([]config.Project, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapped projectCache
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse project cache %s: %w", filename, err)
+	}
+
+	cached := wrapped.Projects
+	projects := make([]config.Project, len(cached))
+	for i, entry := range cached {
+		slackRoom := strings.TrimSpace(entry.SlackRoom)
+		if slackRoom == "#none" {
+			slackRoom = ""
+		}
+
+		projects[i] = config.Project{
+			Repo:           entry.Repo,
+			SlackRoom:      slackRoom,
+			RequiresTicket: entry.RequiresTicket,
+		}
+	}
+
+	return projects, nil
+}
+
+// SaveProjects writes the provided projects to disk as YAML.
+func SaveProjects(filename string, projects []config.Project) error {
+	byRepo := make(map[string]cachedProject)
+
+	if existingData, err := os.ReadFile(filename); err == nil {
+		var existing projectCache
+		if err := yaml.Unmarshal(existingData, &existing); err == nil {
+			for _, entry := range existing.Projects {
+				repo := strings.TrimSpace(entry.Repo)
+				if repo == "" {
+					continue
+				}
+				byRepo[repo] = entry
+			}
+		}
+	}
+
+	for _, project := range projects {
+		repo := strings.TrimSpace(project.Repo)
+		if repo == "" {
+			continue
+		}
+
+		slackRoom := strings.TrimSpace(project.SlackRoom)
+
+		existing, found := byRepo[repo]
+		if !found {
+			existing = cachedProject{Repo: repo}
+		}
+
+		if slackRoom != "" {
+			existing.SlackRoom = slackRoom
+		}
+
+		if strings.TrimSpace(existing.SlackRoom) == "" {
+			existing.SlackRoom = "#none"
+		}
+
+		existing.RequiresTicket = project.RequiresTicket
+
+		byRepo[repo] = existing
+	}
+
+	merged := make([]cachedProject, 0, len(byRepo))
+	for _, entry := range byRepo {
+		merged = append(merged, entry)
+	}
+
+	// Keep cache stable to reduce noise in diffs.
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Repo < merged[j].Repo
+	})
+
+	data, err := yaml.Marshal(&projectCache{Projects: merged})
+	if err != nil {
+		return fmt.Errorf("failed to encode project cache %s: %w", filename, err)
+	}
+
+	if err := os.WriteFile(filename, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write project cache %s: %w", filename, err)
+	}
+
+	return nil
+}

--- a/internal/cache/projects_test.go
+++ b/internal/cache/projects_test.go
@@ -1,0 +1,337 @@
+package cache
+
+import (
+	"copycat/internal/config"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadProjects(t *testing.T) {
+	tests := []struct {
+		name        string
+		yamlContent string
+		want        []config.Project
+		wantErr     bool
+	}{
+		{
+			name: "valid YAML with multiple projects",
+			yamlContent: `projects:
+  - repo: service-a
+    slack_room: "#team-alpha"
+    requires_ticket: true
+  - repo: service-b
+    slack_room: "#team-beta"
+    requires_ticket: false`,
+			want: []config.Project{
+				{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: true},
+				{Repo: "service-b", SlackRoom: "#team-beta", RequiresTicket: false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty slack room becomes empty string",
+			yamlContent: `projects:
+  - repo: service-a
+    slack_room: ""
+    requires_ticket: false`,
+			want: []config.Project{
+				{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "#none slack room becomes empty string",
+			yamlContent: `projects:
+  - repo: service-a
+    slack_room: "#none"
+    requires_ticket: false`,
+			want: []config.Project{
+				{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "whitespace in slack room is trimmed",
+			yamlContent: `projects:
+  - repo: service-a
+    slack_room: "  #team-alpha  "
+    requires_ticket: false`,
+			want: []config.Project{
+				{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: false},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "invalid YAML",
+			yamlContent: `invalid: yaml: content:`,
+			wantErr:     true,
+		},
+		{
+			name:        "empty projects list",
+			yamlContent: `projects: []`,
+			want:        []config.Project{},
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary file
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "projects.yaml")
+
+			if err := os.WriteFile(tmpFile, []byte(tt.yamlContent), 0o644); err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+
+			got, err := LoadProjects(tmpFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProjects() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Errorf("LoadProjects() got %d projects, want %d", len(got), len(tt.want))
+					return
+				}
+
+				for i := range got {
+					if got[i].Repo != tt.want[i].Repo {
+						t.Errorf("LoadProjects() project[%d].Repo = %v, want %v", i, got[i].Repo, tt.want[i].Repo)
+					}
+					if got[i].SlackRoom != tt.want[i].SlackRoom {
+						t.Errorf("LoadProjects() project[%d].SlackRoom = %v, want %v", i, got[i].SlackRoom, tt.want[i].SlackRoom)
+					}
+					if got[i].RequiresTicket != tt.want[i].RequiresTicket {
+						t.Errorf("LoadProjects() project[%d].RequiresTicket = %v, want %v", i, got[i].RequiresTicket, tt.want[i].RequiresTicket)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestLoadProjectsNonExistentFile(t *testing.T) {
+	_, err := LoadProjects("/nonexistent/file.yaml")
+	if err == nil {
+		t.Error("LoadProjects() expected error for nonexistent file, got nil")
+	}
+}
+
+func TestSaveProjects(t *testing.T) {
+	tests := []struct {
+		name           string
+		existing       string
+		projects       []config.Project
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:     "save new projects",
+			existing: "",
+			projects: []config.Project{
+				{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: true},
+				{Repo: "service-b", SlackRoom: "", RequiresTicket: false},
+			},
+			wantContains: []string{
+				"service-a",
+				"#team-alpha",
+				"requires_ticket: true",
+				"service-b",
+				"#none",
+				"requires_ticket: false",
+			},
+		},
+		{
+			name: "merge with existing projects",
+			existing: `projects:
+  - repo: service-a
+    slack_room: "#old-channel"
+    requires_ticket: false`,
+			projects: []config.Project{
+				{Repo: "service-a", SlackRoom: "#new-channel", RequiresTicket: true},
+			},
+			wantContains: []string{
+				"service-a",
+				"#new-channel",
+				"requires_ticket: true",
+			},
+			wantNotContain: []string{
+				"#old-channel",
+			},
+		},
+		{
+			name: "preserve existing slack room if new is empty",
+			existing: `projects:
+  - repo: service-a
+    slack_room: "#existing-channel"
+    requires_ticket: false`,
+			projects: []config.Project{
+				{Repo: "service-a", SlackRoom: "", RequiresTicket: true},
+			},
+			wantContains: []string{
+				"service-a",
+				"#existing-channel",
+				"requires_ticket: true",
+			},
+		},
+		{
+			name:     "empty slack room becomes #none",
+			existing: "",
+			projects: []config.Project{
+				{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			},
+			wantContains: []string{
+				"service-a",
+				"#none",
+			},
+		},
+		{
+			name:     "projects are sorted alphabetically",
+			existing: "",
+			projects: []config.Project{
+				{Repo: "zebra", SlackRoom: "#z", RequiresTicket: false},
+				{Repo: "alpha", SlackRoom: "#a", RequiresTicket: false},
+				{Repo: "beta", SlackRoom: "#b", RequiresTicket: false},
+			},
+			wantContains: []string{
+				"alpha",
+				"beta",
+				"zebra",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "projects.yaml")
+
+			// Write existing content if provided
+			if tt.existing != "" {
+				if err := os.WriteFile(tmpFile, []byte(tt.existing), 0o644); err != nil {
+					t.Fatalf("Failed to create temp file: %v", err)
+				}
+			}
+
+			// Save projects
+			if err := SaveProjects(tmpFile, tt.projects); err != nil {
+				t.Fatalf("SaveProjects() error = %v", err)
+			}
+
+			// Read back the file
+			content, err := os.ReadFile(tmpFile)
+			if err != nil {
+				t.Fatalf("Failed to read saved file: %v", err)
+			}
+
+			contentStr := string(content)
+
+			// Check that expected strings are present
+			for _, want := range tt.wantContains {
+				if !contains(contentStr, want) {
+					t.Errorf("SaveProjects() content missing %q\nGot:\n%s", want, contentStr)
+				}
+			}
+
+			// Check that unwanted strings are not present
+			for _, notWant := range tt.wantNotContain {
+				if contains(contentStr, notWant) {
+					t.Errorf("SaveProjects() content should not contain %q\nGot:\n%s", notWant, contentStr)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveProjectsRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "projects.yaml")
+
+	original := []config.Project{
+		{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: true},
+		{Repo: "service-b", SlackRoom: "#team-beta", RequiresTicket: false},
+	}
+
+	// Save
+	if err := SaveProjects(tmpFile, original); err != nil {
+		t.Fatalf("SaveProjects() error = %v", err)
+	}
+
+	// Load
+	loaded, err := LoadProjects(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadProjects() error = %v", err)
+	}
+
+	// Compare (order might be different due to sorting)
+	if len(loaded) != len(original) {
+		t.Errorf("Round trip got %d projects, want %d", len(loaded), len(original))
+	}
+
+	// Create a map for comparison
+	loadedMap := make(map[string]config.Project)
+	for _, p := range loaded {
+		loadedMap[p.Repo] = p
+	}
+
+	for _, orig := range original {
+		loaded, ok := loadedMap[orig.Repo]
+		if !ok {
+			t.Errorf("Round trip missing repo %q", orig.Repo)
+			continue
+		}
+
+		if loaded.SlackRoom != orig.SlackRoom {
+			t.Errorf("Round trip repo %q SlackRoom = %q, want %q", orig.Repo, loaded.SlackRoom, orig.SlackRoom)
+		}
+		if loaded.RequiresTicket != orig.RequiresTicket {
+			t.Errorf("Round trip repo %q RequiresTicket = %v, want %v", orig.Repo, loaded.RequiresTicket, orig.RequiresTicket)
+		}
+	}
+}
+
+func TestSaveProjectsSkipsEmptyRepos(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "projects.yaml")
+
+	projects := []config.Project{
+		{Repo: "service-a", SlackRoom: "#team", RequiresTicket: false},
+		{Repo: "", SlackRoom: "#ignored", RequiresTicket: true},
+		{Repo: "  ", SlackRoom: "#also-ignored", RequiresTicket: true},
+	}
+
+	if err := SaveProjects(tmpFile, projects); err != nil {
+		t.Fatalf("SaveProjects() error = %v", err)
+	}
+
+	loaded, err := LoadProjects(tmpFile)
+	if err != nil {
+		t.Fatalf("LoadProjects() error = %v", err)
+	}
+
+	if len(loaded) != 1 {
+		t.Errorf("SaveProjects() saved %d projects, want 1 (empty repos should be skipped)", len(loaded))
+	}
+
+	if loaded[0].Repo != "service-a" {
+		t.Errorf("SaveProjects() saved repo = %q, want %q", loaded[0].Repo, "service-a")
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && indexOf(s, substr) >= 0))
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/git/topics.go
+++ b/internal/git/topics.go
@@ -1,0 +1,212 @@
+package git
+
+import (
+	"copycat/internal/config"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+type repoTopicsResponse struct {
+	Names []string `json:"names"`
+}
+
+var errRepoNotFound = errors.New("repository not found")
+
+// SyncTopicsWithCache ensures GitHub topics reflect the cached project metadata.
+func SyncTopicsWithCache(projects []config.Project, githubCfg config.GitHubConfig) error {
+	if len(projects) == 0 {
+		return nil
+	}
+
+	owner := githubCfg.Organization
+	for _, project := range projects {
+		if err := syncProjectTopics(project, owner, githubCfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func syncProjectTopics(project config.Project, owner string, githubCfg config.GitHubConfig) error {
+	repoSlug := fmt.Sprintf("%s/%s", owner, project.Repo)
+
+	existingTopics, err := fetchRepositoryTopics(owner, project.Repo)
+	if err != nil {
+		if errors.Is(err, errRepoNotFound) {
+			reportTopicFailure(project.Repo)
+			return nil
+		}
+		return fmt.Errorf("failed to fetch topics for %s: %w", repoSlug, err)
+	}
+
+	addTopics, removeTopics := computeTopicChanges(existingTopics, project, githubCfg)
+	if len(addTopics) == 0 && len(removeTopics) == 0 {
+		fmt.Printf("✓ %s topics already up to date\n", project.Repo)
+		return nil
+	}
+
+	args := []string{"repo", "edit", repoSlug}
+	for _, t := range addTopics {
+		args = append(args, "--add-topic", t)
+	}
+	for _, t := range removeTopics {
+		args = append(args, "--remove-topic", t)
+	}
+
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if isNotFoundResponse(string(output)) {
+			reportTopicFailure(project.Repo)
+			return nil
+		}
+		return fmt.Errorf("failed to update topics for %s: %w\nOutput: %s", repoSlug, err, strings.TrimSpace(string(output)))
+	}
+
+	fmt.Printf("✓ Synced topics for %s (added: %s removed: %s)\n", project.Repo, summarizeTopics(addTopics), summarizeTopics(removeTopics))
+	return nil
+}
+
+func fetchRepositoryTopics(owner, repo string) ([]string, error) {
+	args := []string{
+		"api",
+		fmt.Sprintf("repos/%s/%s/topics", owner, repo),
+		"-H", "Accept: application/vnd.github+json",
+	}
+
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		outputStr := strings.TrimSpace(string(output))
+		if isNotFoundResponse(outputStr) {
+			return nil, fmt.Errorf("%w: %s", errRepoNotFound, outputStr)
+		}
+		return nil, fmt.Errorf("gh api fetch topics failed: %w\nOutput: %s", err, strings.TrimSpace(string(output)))
+	}
+
+	var resp repoTopicsResponse
+	if err := json.Unmarshal(output, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse topics response: %w", err)
+	}
+
+	// Deduplicate and sort for consistency.
+	unique := make(map[string]struct{}, len(resp.Names))
+	for _, name := range resp.Names {
+		if name != "" {
+			unique[name] = struct{}{}
+		}
+	}
+
+	topics := make([]string, 0, len(unique))
+	for name := range unique {
+		topics = append(topics, name)
+	}
+
+	sort.Strings(topics)
+	return topics, nil
+}
+
+func computeTopicChanges(existing []string, project config.Project, githubCfg config.GitHubConfig) (addTopics []string, removeTopics []string) {
+	existingSet := make(map[string]struct{}, len(existing))
+	for _, topic := range existing {
+		existingSet[topic] = struct{}{}
+	}
+
+	discoveryTopic := strings.TrimSpace(githubCfg.AutoDiscoveryTopic)
+	if discoveryTopic != "" {
+		if _, hasTopic := existingSet[discoveryTopic]; !hasTopic {
+			addTopics = append(addTopics, discoveryTopic)
+		}
+	}
+
+	requiresTopic := strings.TrimSpace(githubCfg.RequiresTicketTopic)
+	if requiresTopic != "" {
+		_, hasTopic := existingSet[requiresTopic]
+		if project.RequiresTicket && !hasTopic {
+			addTopics = append(addTopics, requiresTopic)
+		}
+		if !project.RequiresTicket && hasTopic {
+			removeTopics = append(removeTopics, requiresTopic)
+		}
+	}
+
+	slackPrefix := strings.TrimSpace(githubCfg.SlackRoomTopicPrefix)
+	if slackPrefix != "" {
+		targetSlackTopic := ""
+		slackRoom := strings.TrimSpace(project.SlackRoom)
+		if slackRoom != "" {
+			slackRoom = strings.TrimPrefix(slackRoom, "#")
+			slackRoom = strings.TrimSpace(slackRoom)
+			if slackRoom != "" {
+				targetSlackTopic = slackPrefix + slackRoom
+			}
+		}
+
+		hasTarget := false
+		for _, topic := range existing {
+			if strings.HasPrefix(topic, slackPrefix) {
+				if targetSlackTopic == "" || topic != targetSlackTopic {
+					removeTopics = append(removeTopics, topic)
+				}
+				if topic == targetSlackTopic {
+					hasTarget = true
+				}
+			}
+		}
+
+		if targetSlackTopic != "" && !hasTarget {
+			addTopics = append(addTopics, targetSlackTopic)
+		}
+	}
+
+	addTopics = deduplicate(addTopics)
+	removeTopics = deduplicate(removeTopics)
+
+	return addTopics, removeTopics
+}
+
+func deduplicate(items []string) []string {
+	if len(items) <= 1 {
+		return items
+	}
+
+	seen := make(map[string]struct{}, len(items))
+	var result []string
+	for _, item := range items {
+		if item == "" {
+			continue
+		}
+		if _, exists := seen[item]; exists {
+			continue
+		}
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+
+	return result
+}
+
+func summarizeTopics(items []string) string {
+	if len(items) == 0 {
+		return "none"
+	}
+	return strings.Join(items, ", ")
+}
+
+func isNotFoundResponse(output string) bool {
+	if output == "" {
+		return false
+	}
+
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "404") && strings.Contains(lower, "not found")
+}
+
+func reportTopicFailure(repo string) {
+	fmt.Printf("✘ %s (could not update topics in repository)\n", repo)
+}

--- a/internal/git/topics_test.go
+++ b/internal/git/topics_test.go
@@ -1,0 +1,362 @@
+package git
+
+import (
+	"copycat/internal/config"
+	"reflect"
+	"testing"
+)
+
+func TestDeduplicate(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []string
+		want  []string
+	}{
+		{
+			name:  "empty list",
+			items: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "single item",
+			items: []string{"topic-a"},
+			want:  []string{"topic-a"},
+		},
+		{
+			name:  "no duplicates",
+			items: []string{"topic-a", "topic-b", "topic-c"},
+			want:  []string{"topic-a", "topic-b", "topic-c"},
+		},
+		{
+			name:  "with duplicates",
+			items: []string{"topic-a", "topic-b", "topic-a", "topic-c", "topic-b"},
+			want:  []string{"topic-a", "topic-b", "topic-c"},
+		},
+		{
+			name:  "empty strings filtered out",
+			items: []string{"topic-a", "", "topic-b", ""},
+			want:  []string{"topic-a", "topic-b"},
+		},
+		{
+			name:  "all empty strings",
+			items: []string{"", "", ""},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicate(tt.items)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deduplicate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSummarizeTopics(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []string
+		want  string
+	}{
+		{
+			name:  "empty list",
+			items: []string{},
+			want:  "none",
+		},
+		{
+			name:  "single topic",
+			items: []string{"topic-a"},
+			want:  "topic-a",
+		},
+		{
+			name:  "multiple topics",
+			items: []string{"topic-a", "topic-b", "topic-c"},
+			want:  "topic-a, topic-b, topic-c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeTopics(tt.items)
+			if got != tt.want {
+				t.Errorf("summarizeTopics() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNotFoundResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "empty string",
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "404 not found",
+			output: "HTTP 404: Not Found (https://api.github.com/repos/org/repo)",
+			want:   true,
+		},
+		{
+			name:   "404 lowercase",
+			output: "http 404: not found",
+			want:   true,
+		},
+		{
+			name:   "404 only",
+			output: "404",
+			want:   false,
+		},
+		{
+			name:   "not found only",
+			output: "not found",
+			want:   false,
+		},
+		{
+			name:   "success message",
+			output: "Successfully updated topics",
+			want:   false,
+		},
+		{
+			name:   "other error",
+			output: "permission denied",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isNotFoundResponse(tt.output)
+			if got != tt.want {
+				t.Errorf("isNotFoundResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeTopicChanges(t *testing.T) {
+	tests := []struct {
+		name          string
+		existing      []string
+		project       config.Project
+		githubCfg     config.GitHubConfig
+		wantAdd       []string
+		wantRemove    []string
+		description   string
+	}{
+		{
+			name:     "add auto-discovery topic when missing",
+			existing: []string{},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic: "copycat",
+			},
+			wantAdd:     []string{"copycat"},
+			wantRemove:  nil,
+			description: "Should add auto-discovery topic when not present",
+		},
+		{
+			name:     "auto-discovery topic already exists",
+			existing: []string{"copycat"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic: "copycat",
+			},
+			wantAdd:     nil,
+			wantRemove:  nil,
+			description: "Should not add auto-discovery topic if already present",
+		},
+		{
+			name:     "add requires-ticket topic",
+			existing: []string{"copycat"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: true},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:  "copycat",
+				RequiresTicketTopic: "requires-ticket",
+			},
+			wantAdd:     []string{"requires-ticket"},
+			wantRemove:  nil,
+			description: "Should add requires-ticket topic when RequiresTicket is true",
+		},
+		{
+			name:     "remove requires-ticket topic",
+			existing: []string{"copycat", "requires-ticket"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:  "copycat",
+				RequiresTicketTopic: "requires-ticket",
+			},
+			wantAdd:     nil,
+			wantRemove:  []string{"requires-ticket"},
+			description: "Should remove requires-ticket topic when RequiresTicket is false",
+		},
+		{
+			name:     "add slack room topic",
+			existing: []string{"copycat"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"slack-team-alpha"},
+			wantRemove:  nil,
+			description: "Should add slack topic with prefix (# stripped)",
+		},
+		{
+			name:     "update slack room topic",
+			existing: []string{"copycat", "slack-old-channel"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#new-channel", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"slack-new-channel"},
+			wantRemove:  []string{"slack-old-channel"},
+			description: "Should replace old slack topic with new one",
+		},
+		{
+			name:     "remove slack topic when slack room is empty",
+			existing: []string{"copycat", "slack-old-channel"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     nil,
+			wantRemove:  []string{"slack-old-channel"},
+			description: "Should remove slack topic when project has no slack room",
+		},
+		{
+			name:     "slack room with # prefix is stripped",
+			existing: []string{"copycat"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"slack-team-alpha"},
+			wantRemove:  nil,
+			description: "Should strip # prefix from slack room name",
+		},
+		{
+			name:     "complex scenario with multiple changes",
+			existing: []string{"copycat", "slack-old-channel", "other-topic"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#new-channel", RequiresTicket: true},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				RequiresTicketTopic:  "requires-ticket",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"requires-ticket", "slack-new-channel"},
+			wantRemove:  []string{"slack-old-channel"},
+			description: "Should handle multiple topic changes at once",
+		},
+		{
+			name:     "no changes needed",
+			existing: []string{"copycat", "requires-ticket", "slack-team-alpha"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#team-alpha", RequiresTicket: true},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				RequiresTicketTopic:  "requires-ticket",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     nil,
+			wantRemove:  nil,
+			description: "Should return empty when all topics are correct",
+		},
+		{
+			name:     "empty config values",
+			existing: []string{"some-topic"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "",
+				RequiresTicketTopic:  "",
+				SlackRoomTopicPrefix: "",
+			},
+			wantAdd:     nil,
+			wantRemove:  nil,
+			description: "Should handle empty config values gracefully",
+		},
+		{
+			name:     "whitespace in slack room",
+			existing: []string{"copycat"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "  #team-alpha  ", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"slack-team-alpha"},
+			wantRemove:  nil,
+			description: "Should trim whitespace from slack room",
+		},
+		{
+			name:     "multiple slack topics removed",
+			existing: []string{"copycat", "slack-channel-a", "slack-channel-b"},
+			project:  config.Project{Repo: "service-a", SlackRoom: "#new-channel", RequiresTicket: false},
+			githubCfg: config.GitHubConfig{
+				AutoDiscoveryTopic:   "copycat",
+				SlackRoomTopicPrefix: "slack-",
+			},
+			wantAdd:     []string{"slack-new-channel"},
+			wantRemove:  []string{"slack-channel-a", "slack-channel-b"},
+			description: "Should remove all old slack topics with matching prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdd, gotRemove := computeTopicChanges(tt.existing, tt.project, tt.githubCfg)
+
+			if !equalSlices(gotAdd, tt.wantAdd) {
+				t.Errorf("computeTopicChanges() add = %v, want %v\nDescription: %s", gotAdd, tt.wantAdd, tt.description)
+			}
+
+			if !equalSlices(gotRemove, tt.wantRemove) {
+				t.Errorf("computeTopicChanges() remove = %v, want %v\nDescription: %s", gotRemove, tt.wantRemove, tt.description)
+			}
+		})
+	}
+}
+
+func TestSyncTopicsWithCacheEmptyProjects(t *testing.T) {
+	githubCfg := config.GitHubConfig{
+		Organization:       "test-org",
+		AutoDiscoveryTopic: "copycat",
+	}
+
+	err := SyncTopicsWithCache([]config.Project{}, githubCfg)
+	if err != nil {
+		t.Errorf("SyncTopicsWithCache() with empty projects should not error, got: %v", err)
+	}
+}
+
+// Helper function to compare slices ignoring order
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+
+	// Create maps for comparison
+	aMap := make(map[string]int)
+	bMap := make(map[string]int)
+
+	for _, item := range a {
+		aMap[item]++
+	}
+
+	for _, item := range b {
+		bMap[item]++
+	}
+
+	return reflect.DeepEqual(aMap, bMap)
+}

--- a/internal/input/ai_prompt.go
+++ b/internal/input/ai_prompt.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"bufio"
 	"copycat/internal/config"
 	"fmt"
 	"log"
@@ -19,58 +18,54 @@ func ReadAIPrompt(aiTool *config.AITool) string {
 		log.Fatal("Failed to select input method:", err)
 	}
 
-	var aiPrompt string
-
 	if inputMethod == "Single line" {
-		reader := bufio.NewReader(os.Stdin)
-		fmt.Print("Prompt: ")
-		line, err := reader.ReadString('\n')
+		title := fmt.Sprintf("%s Prompt", aiTool.Name)
+		placeholder := "Describe the instructions to run in each repository"
+		prompt, err := GetTextInputWithLimit(title, placeholder, 2048)
 		if err != nil {
 			log.Fatal("Failed to read prompt:", err)
 		}
-		aiPrompt = strings.TrimSpace(line)
-	} else {
-		// Create a temporary file for the prompt
-		tmpFile, err := os.CreateTemp("", "copycat-prompt-*.txt")
-		if err != nil {
-			log.Fatal("Failed to create temp file:", err)
-		}
-		tmpFilePath := tmpFile.Name()
-
-		if err := tmpFile.Close(); err != nil {
-			log.Fatal("Failed to close temp file:", err)
-		}
-		defer func() {
-			if err := os.Remove(tmpFilePath); err != nil {
-				log.Println("Failed to remove temp file:", err)
-			}
-		}()
-
-		// Get the editor from environment or use vim as default
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			editor = "vim"
-		}
-
-		// Open the editor
-		cmd := exec.Command(editor, tmpFilePath)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		err = cmd.Run()
-		if err != nil {
-			log.Fatal("Failed to run editor:", err)
-		}
-
-		// Read the content from the temp file
-		content, err := os.ReadFile(tmpFilePath)
-		if err != nil {
-			log.Fatal("Failed to read prompt from temp file:", err)
-		}
-
-		aiPrompt = strings.TrimSpace(string(content))
+		return prompt
 	}
 
-	return aiPrompt
+	// Create a temporary file for the prompt
+	tmpFile, err := os.CreateTemp("", "copycat-prompt-*.txt")
+	if err != nil {
+		log.Fatal("Failed to create temp file:", err)
+	}
+	tmpFilePath := tmpFile.Name()
+
+	if err := tmpFile.Close(); err != nil {
+		log.Fatal("Failed to close temp file:", err)
+	}
+	defer func() {
+		if err := os.Remove(tmpFilePath); err != nil {
+			log.Println("Failed to remove temp file:", err)
+		}
+	}()
+
+	// Get the editor from environment or use vim as default
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+
+	// Open the editor
+	cmd := exec.Command(editor, tmpFilePath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal("Failed to run editor:", err)
+	}
+
+	// Read the content from the temp file
+	content, err := os.ReadFile(tmpFilePath)
+	if err != nil {
+		log.Fatal("Failed to read prompt from temp file:", err)
+	}
+
+	return strings.TrimSpace(string(content))
 }

--- a/internal/input/text_input.go
+++ b/internal/input/text_input.go
@@ -17,10 +17,17 @@ type textInputModel struct {
 }
 
 func initialTextInputModel(title, placeholder string) textInputModel {
+	return initialTextInputModelWithLimit(title, placeholder, 256)
+}
+
+func initialTextInputModelWithLimit(title, placeholder string, charLimit int) textInputModel {
 	ti := textinput.New()
 	ti.Placeholder = placeholder
 	ti.Focus()
-	ti.CharLimit = 256
+	if charLimit <= 0 {
+		charLimit = 256
+	}
+	ti.CharLimit = charLimit
 	ti.Width = 80
 
 	return textInputModel{
@@ -88,7 +95,12 @@ func (m textInputModel) View() string {
 
 // GetTextInput prompts the user to enter text
 func GetTextInput(title, placeholder string) (string, error) {
-	p := tea.NewProgram(initialTextInputModel(title, placeholder))
+	return GetTextInputWithLimit(title, placeholder, 256)
+}
+
+// GetTextInputWithLimit prompts the user to enter text with a custom character limit
+func GetTextInputWithLimit(title, placeholder string, charLimit int) (string, error) {
+	p := tea.NewProgram(initialTextInputModelWithLimit(title, placeholder, charLimit))
 	finalModel, err := p.Run()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The main change in this PR introduces a few differences in the workflow:
- When the project list is first fetched from it will create a cache file `.projects.yaml`
- In the project selector:
  - The file can be refreshed from GitHub with the `r` option.
  - The file can be synced back to GitHub (by updating the repository topics) with the `s` option.
- The refresh will attempt to merge instead of simply replacing the contents.

Other changes in this PR:
- Using Charm Bracelet for the AI prompt text to provide better navigation/editing experience and make it consistent with other inputs.