### PR TITLE
fix: signed commits warning

### DIFF
--- a/internal/input/ai_tool.go
+++ b/internal/input/ai_tool.go
@@ -94,8 +94,7 @@ func (m aiToolSelectorModel) View() string {
 		if i == m.cursor {
 			itemStyle = itemStyle.
 				Foreground(lipgloss.Color("205")).
-				Bold(true).
-				Underline(true)
+				Bold(true)
 			itemText = "> " + itemText
 		} else {
 			itemText = "  " + itemText

--- a/internal/input/projects.go
+++ b/internal/input/projects.go
@@ -206,8 +206,7 @@ func (m projectSelectorModel) View() string {
 			if idx == m.cursor {
 				itemStyle = itemStyle.
 					Foreground(lipgloss.Color("205")).
-					Bold(true).
-					Underline(true)
+					Bold(true)
 			}
 
 			rowItems = append(rowItems, itemStyle.Render(itemText))

--- a/internal/input/selector.go
+++ b/internal/input/selector.go
@@ -85,8 +85,7 @@ func (m selectorModel) View() string {
 		if i == m.cursor {
 			itemStyle = itemStyle.
 				Foreground(lipgloss.Color("205")).
-				Bold(true).
-				Underline(true)
+				Bold(true)
 			itemText = "> " + itemText
 		} else {
 			itemText = "  " + itemText

--- a/main.go
+++ b/main.go
@@ -113,19 +113,19 @@ func main() {
 	}
 
 	// Ask user to choose the workflow
-	action, err := input.SelectOption("Choose an action", []string{"Create GitHub Issues", "Perform Changes Locally"})
+	action, err := input.SelectOption("Choose an action", []string{
+		"Perform Changes Locally",
+		"Create GitHub Issues (⚠️ Copilot does not sign commits)",
+	})
 	if err != nil {
 		fmt.Println("Action selection cancelled. Exiting.")
 		return
 	}
 
-	switch action {
-	case "Create GitHub Issues":
-		fmt.Println("\n⚠️  WARNING: The Copilot agent does not sign commits.")
-		fmt.Println("You will need to fix unsigned commits before merging any pull request.")
-		fmt.Println("")
+	switch {
+	case strings.HasPrefix(action, "Create GitHub Issues"):
 		git.CreateGitHubIssues(selectedProjects)
-	case "Perform Changes Locally":
+	case strings.HasPrefix(action, "Perform Changes Locally"):
 		performChangesLocally(selectedProjects, selectedTool)
 	}
 


### PR DESCRIPTION
Changes:
- Show warning about Copilot not signing commits before selecting the option, for a better navigation experience.
- Consistent experience without underlines on selected options.

Related discussion:
- https://github.com/orgs/community/discussions/164099

Screenshot:
<img width="471" height="110" alt="image" src="https://github.com/user-attachments/assets/89f22757-4e21-4f42-a6a1-a5fd8ae59551" />
