### PR TITLE
feat: project filtering

### DIFF
--- a/.projects.yaml.example
+++ b/.projects.yaml.example
@@ -1,0 +1,10 @@
+projects:
+    - repo: foo-service
+      slack_room: '#team-foo'
+      requires_ticket: false
+      topics:
+        - slack-team-foo
+        - copycat
+        - java
+    - repo: bar-service
+      requires_ticket: true

--- a/internal/cache/projects.go
+++ b/internal/cache/projects.go
@@ -11,9 +11,10 @@ import (
 )
 
 type cachedProject struct {
-	Repo           string `yaml:"repo"`
-	SlackRoom      string `yaml:"slack_room"`
-	RequiresTicket bool   `yaml:"requires_ticket"`
+	Repo           string   `yaml:"repo"`
+	SlackRoom      string   `yaml:"slack_room"`
+	RequiresTicket bool     `yaml:"requires_ticket"`
+	Topics         []string `yaml:"topics,omitempty"`
 }
 
 type projectCache struct {
@@ -44,6 +45,7 @@ func LoadProjects(filename string) ([]config.Project, error) {
 			Repo:           entry.Repo,
 			SlackRoom:      slackRoom,
 			RequiresTicket: entry.RequiresTicket,
+			Topics:         entry.Topics,
 		}
 	}
 
@@ -89,6 +91,7 @@ func SaveProjects(filename string, projects []config.Project) error {
 		}
 
 		existing.RequiresTicket = project.RequiresTicket
+		existing.Topics = project.Topics
 
 		byRepo[repo] = existing
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Project struct {
-	Repo           string `yaml:"repo"`
-	SlackRoom      string `yaml:"slack_room"`
-	RequiresTicket bool   `yaml:"requires_ticket"`
+	Repo           string   `yaml:"repo"`
+	SlackRoom      string   `yaml:"slack_room"`
+	RequiresTicket bool     `yaml:"requires_ticket"`
+	Topics         []string `yaml:"topics,omitempty"`
 }
 
 type GitHubConfig struct {

--- a/internal/git/repos.go
+++ b/internal/git/repos.go
@@ -64,10 +64,17 @@ func FetchRepositories(githubCfg config.GitHubConfig) ([]config.Project, error) 
 			}
 		}
 
+		// Extract topic names from repository topics
+		var topics []string
+		for _, topic := range repo.RepositoryTopics {
+			topics = append(topics, topic.Topic)
+		}
+
 		project := config.Project{
 			Repo:           repo.Name,
 			SlackRoom:      slackRoom,
 			RequiresTicket: requiresTicket,
+			Topics:         topics,
 		}
 		projects = append(projects, project)
 	}

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 	case strings.HasPrefix(action, "Create GitHub Issues"):
 		git.CreateGitHubIssues(selectedProjects)
 	case strings.HasPrefix(action, "Perform Changes Locally"):
-		performChangesLocally(selectedProjects, selectedTool)
+		performChangesLocally(selectedProjects, selectedTool, *appConfig)
 	}
 
 	fmt.Println("\nDone!")
@@ -184,7 +184,7 @@ func fetchAndCacheProjectList(githubCfg config.GitHubConfig) ([]config.Project, 
 	return mergedProjects, nil
 }
 
-func performChangesLocally(selectedProjects []config.Project, aiTool *config.AITool) {
+func performChangesLocally(selectedProjects []config.Project, aiTool *config.AITool, appConfig config.Config) {
 	// ============================================================
 	// STEP 1: Collect all user inputs BEFORE any cloning/changes
 	// ============================================================
@@ -256,8 +256,8 @@ func performChangesLocally(selectedProjects []config.Project, aiTool *config.AIT
 		if _, err := os.Stat(targetPath); os.IsNotExist(err) {
 			fmt.Printf("\nCloning %s...\n", project.Repo)
 
-			// Use SSH URL for cloning
-			repoURL := fmt.Sprintf("git@github.com:saltpay/%s.git", project.Repo)
+			// Use SSH URL for cloning with the configured organization
+			repoURL := fmt.Sprintf("git@github.com:%s/%s.git", appConfig.GitHub.Organization, project.Repo)
 
 			cmd := exec.Command("git", "clone", repoURL, targetPath)
 			output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## 🆕 Features
- This change implements a functionality to allow selecting projects by filtering topics.  

## 🐛 Bug fixes
- Remove hardcoded organization and use the organization value from the config file.

## 🎬 Demo

Considering the following project setup:

```yaml
projects:
    - repo: foo-service
      slack_room: '#team-foo'
      requires_ticket: false
      topics:
        - slack-team-foo
        - copycat
        - java
    - repo: bar-service
      requires_ticket: true
```

https://github.com/user-attachments/assets/3c631e90-a575-4021-9645-8a975514f769

