### PR TITLE
Fix claude configs when running in standalone

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,9 +9,11 @@ tools:
   - name: claude
     command: claude
     code_args:
+      - --print
       - --permission-mode
       - acceptEdits
-    summary_args: []
+    summary_args:
+      - --print
   - name: codex
     command: codex
     code_args:


### PR DESCRIPTION
This pull request updates the configuration for the `claude` tool to ensure that the `--print` argument is included when running both code and summary commands. This change should help with debugging or logging by making output more visible.

Configuration updates for `claude` tool:

* Added the `--print` argument to both `code_args` and `summary_args` for the `claude` tool in `config.yaml`, ensuring output is printed during code and summary executions.