### PR TITLE
feat: add repo alias support and fix .git suffix bug

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,58 @@
+# Copycat Proposed Improvements
+
+Six improvement areas identified from team feedback and real-world usage.
+
+## 1. Repo Resolution / Alias Handling (Priority: High)
+
+**Problem**: Repo identification assumes exact name match. Users can't use service names, abbreviations, or aliases (e.g., `merchant-account` not found). Also a `.git` trimming bug where config values like `repo.git` produce clone URLs `repo.git.git`.
+
+**Solution**:
+- Add `aliases` field to Project config
+- Strip `.git` suffix on load (defensive normalization)
+- Extend filter matching to search repo names and aliases, not just topics
+- Add fuzzy suggestion when exact match fails
+
+## 2. Batch-Run Preflight Checks and Approval UX (Priority: High)
+
+**Problem**: Users hit issues after batch approval — repos fail due to missing Jira tickets, auth issues, or inaccessible repos. One user reported a loop after batch approve.
+
+**Solution**:
+- Add preflight validation phase (check repo accessibility via `gh repo view`)
+- Skip blocked repos gracefully instead of failing
+- Fix batch-pause loop bug (`!m.paused` guard in progress.go:223)
+
+## 3. Text Attachments / Richer Prompt Inputs (Priority: Medium)
+
+**Problem**: Users can't attach files (migration guides, spec documents) to provide context for the AI.
+
+**Solution**:
+- Add `stepAttachments` wizard step after prompt input
+- Concatenate file contents into the prompt sent to AI
+- 50KB size limit per attachment
+
+## 4. Better Ambiguity Handling Before Editing Code (Priority: Medium)
+
+**Problem**: AI acts on ambiguous prompts without clarifying, leading to wrong changes (e.g., adding producer instead of consumer).
+
+**Solution**:
+- Add plan preview phase: clone first repo, run AI in read-only mode to describe planned changes
+- User can proceed, edit prompt, or cancel before committing to batch
+- Optional `--dry-run` CLI flag
+
+## 5. More Robust PR Follow-up / Workspace Targeting (Priority: Medium)
+
+**Problem**: Can't apply feedback to PRs in different repos/workspaces than the one currently open.
+
+**Solution**:
+- Add "Follow Up on PR" action in wizard
+- Clone repo, checkout PR branch, apply changes, push (PR auto-updates)
+- No new PR creation needed
+
+## 6. Clearer Task Boundaries / Fallback Modes (Priority: Low)
+
+**Problem**: When asked to "investigate", Copycat says it's outside its toolkit. Assessment mode exists but isn't surfaced well.
+
+**Solution**:
+- Rename actions with inline descriptions ("Investigate" instead of "Run Assessment")
+- Add prompt templates for investigation use cases
+- Pattern-match AI refusal output and suggest appropriate mode

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Welcome to Copycat, a way to copy changes from one git repository to another.
 
-<img src="./logo.png"
-     alt="Copycat logo"
-     style="margin-bottom: 10px; animation: spin 2s linear infinite; transform-origin: center center;" />
+<img src="./logo.png" alt="Copycat logo" width="200" />
 
 Copycat is an automation tool that enables you to apply consistent changes across multiple GitHub repositories using AI coding assistants. It streamlines the process of creating issues or performing code changes at scale with support for multiple AI tools including Claude, Codex, Qwen, and others.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 type Project struct {
 	Repo      string   `yaml:"repo"`
+	Aliases   []string `yaml:"aliases,omitempty"`
 	SlackRoom string   `yaml:"slack_room"`
 	Topics    []string `yaml:"topics,omitempty"`
 }
@@ -142,6 +144,12 @@ func (c *AIToolsConfig) ToolByName(name string) (*AITool, bool) {
 	return nil, false
 }
 
+// trimGitSuffix removes a trailing ".git" suffix from a repo name to prevent
+// double-suffix bugs when constructing clone URLs.
+func trimGitSuffix(name string) string {
+	return strings.TrimSuffix(name, ".git")
+}
+
 // Save writes the configuration to a file with readable formatting.
 func (c *Config) Save(filename string) error {
 	// Marshal each section separately to add spacing between them
@@ -189,6 +197,10 @@ func LoadProjects(filename string) ([]Project, error) {
 	}
 	if err := yaml.Unmarshal(data, &wrapper); err != nil {
 		return nil, fmt.Errorf("failed to parse projects file %s: %w", filename, err)
+	}
+
+	for i := range wrapper.Projects {
+		wrapper.Projects[i].Repo = trimGitSuffix(wrapper.Projects[i].Repo)
 	}
 
 	return wrapper.Projects, nil

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+// FindProjectByNameOrAlias resolves a project by name or alias.
+// Returns the matched project, up to 3 suggestions if no match, and whether a match was found.
+// Resolution order: exact repo name, exact alias, case-insensitive substring on repo name.
+func FindProjectByNameOrAlias(name string, projects []Project) (Project, []string, bool) {
+	nameLower := strings.ToLower(name)
+
+	// 1. Exact match on Repo
+	for _, p := range projects {
+		if p.Repo == name {
+			return p, nil, true
+		}
+	}
+
+	// 2. Exact match on any Alias
+	for _, p := range projects {
+		for _, alias := range p.Aliases {
+			if alias == name {
+				return p, nil, true
+			}
+		}
+	}
+
+	// 3. Case-insensitive substring match on Repo
+	for _, p := range projects {
+		if strings.Contains(strings.ToLower(p.Repo), nameLower) {
+			return p, nil, true
+		}
+	}
+
+	// 4. No match — return Levenshtein-based suggestions
+	suggestions := closestNames(name, projects, 3)
+	return Project{}, suggestions, false
+}
+
+// closestNames returns up to n project repo names sorted by Levenshtein distance to the query.
+func closestNames(query string, projects []Project, n int) []string {
+	type scored struct {
+		name string
+		dist int
+	}
+
+	queryLower := strings.ToLower(query)
+	var candidates []scored
+	for _, p := range projects {
+		d := levenshtein(queryLower, strings.ToLower(p.Repo))
+		candidates = append(candidates, scored{name: p.Repo, dist: d})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].dist < candidates[j].dist
+	})
+
+	var result []string
+	for i := 0; i < n && i < len(candidates); i++ {
+		result = append(result, candidates[i].name)
+	}
+	return result
+}
+
+// levenshtein computes the edit distance between two strings.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -1,0 +1,145 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestFindProjectByNameOrAlias_ExactRepoMatch(t *testing.T) {
+	projects := []Project{
+		{Repo: "merchant-account-service"},
+		{Repo: "payment-gateway"},
+	}
+
+	got, _, found := FindProjectByNameOrAlias("merchant-account-service", projects)
+	if !found {
+		t.Fatal("expected match, got none")
+	}
+	if got.Repo != "merchant-account-service" {
+		t.Fatalf("expected merchant-account-service, got %s", got.Repo)
+	}
+}
+
+func TestFindProjectByNameOrAlias_ExactAliasMatch(t *testing.T) {
+	projects := []Project{
+		{Repo: "merchant-account-service", Aliases: []string{"merchant-account", "mas"}},
+		{Repo: "payment-gateway"},
+	}
+
+	got, _, found := FindProjectByNameOrAlias("merchant-account", projects)
+	if !found {
+		t.Fatal("expected match via alias, got none")
+	}
+	if got.Repo != "merchant-account-service" {
+		t.Fatalf("expected merchant-account-service, got %s", got.Repo)
+	}
+
+	got, _, found = FindProjectByNameOrAlias("mas", projects)
+	if !found {
+		t.Fatal("expected match via short alias, got none")
+	}
+	if got.Repo != "merchant-account-service" {
+		t.Fatalf("expected merchant-account-service, got %s", got.Repo)
+	}
+}
+
+func TestFindProjectByNameOrAlias_SubstringMatch(t *testing.T) {
+	projects := []Project{
+		{Repo: "merchant-account-service"},
+		{Repo: "payment-gateway"},
+	}
+
+	got, _, found := FindProjectByNameOrAlias("merchant-account", projects)
+	if !found {
+		t.Fatal("expected substring match, got none")
+	}
+	if got.Repo != "merchant-account-service" {
+		t.Fatalf("expected merchant-account-service, got %s", got.Repo)
+	}
+}
+
+func TestFindProjectByNameOrAlias_CaseInsensitiveSubstring(t *testing.T) {
+	projects := []Project{
+		{Repo: "Payment-Gateway"},
+	}
+
+	got, _, found := FindProjectByNameOrAlias("payment", projects)
+	if !found {
+		t.Fatal("expected case-insensitive match, got none")
+	}
+	if got.Repo != "Payment-Gateway" {
+		t.Fatalf("expected Payment-Gateway, got %s", got.Repo)
+	}
+}
+
+func TestFindProjectByNameOrAlias_NoMatch_ReturnsSuggestions(t *testing.T) {
+	projects := []Project{
+		{Repo: "merchant-account-service"},
+		{Repo: "merchant-api"},
+		{Repo: "payment-gateway"},
+		{Repo: "auth-service"},
+	}
+
+	_, suggestions, found := FindProjectByNameOrAlias("merchant-acount", projects)
+	if found {
+		t.Fatal("expected no match for typo")
+	}
+	if len(suggestions) == 0 {
+		t.Fatal("expected suggestions, got none")
+	}
+	if len(suggestions) > 3 {
+		t.Fatalf("expected at most 3 suggestions, got %d", len(suggestions))
+	}
+	// The closest match should be merchant-account-service or merchant-api
+	if suggestions[0] != "merchant-api" && suggestions[0] != "merchant-account-service" {
+		t.Fatalf("expected a merchant-* suggestion first, got %s", suggestions[0])
+	}
+}
+
+func TestFindProjectByNameOrAlias_EmptyProjects(t *testing.T) {
+	_, suggestions, found := FindProjectByNameOrAlias("anything", nil)
+	if found {
+		t.Fatal("expected no match on empty list")
+	}
+	if len(suggestions) != 0 {
+		t.Fatalf("expected no suggestions on empty list, got %d", len(suggestions))
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		got := levenshtein(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestGitSuffixNormalization(t *testing.T) {
+	// This tests the normalization that happens in LoadProjects.
+	// We test the TrimSuffix logic directly since LoadProjects needs a file.
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"repo-name", "repo-name"},
+		{"repo-name.git", "repo-name"},
+		{"repo.git.git", "repo.git"},
+	}
+	for _, tt := range tests {
+		got := trimGitSuffix(tt.input)
+		if got != tt.want {
+			t.Errorf("trimGitSuffix(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/git/repos.go
+++ b/internal/git/repos.go
@@ -3,6 +3,7 @@ package git
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/saltpay/copycat/v2/internal/config"
 )
@@ -48,7 +49,7 @@ func FetchRepositories(githubCfg config.GitHubConfig) ([]config.Project, error) 
 		}
 
 		project := config.Project{
-			Repo:   repo.Name,
+			Repo:   strings.TrimSuffix(repo.Name, ".git"),
 			Topics: topics,
 		}
 		projects = append(projects, project)

--- a/internal/input/projects.go
+++ b/internal/input/projects.go
@@ -294,18 +294,28 @@ func (m projectSelectorModel) filterProjectsByTopic(filterText string) []config.
 	terms := strings.Fields(filterTextLower)
 
 	for _, project := range m.projects {
-		// Check if the project has any of the terms in its topics
+		// Check if the project matches any of the terms via topics, repo name, or aliases
 		anyTermMatches := false
 		for _, term := range terms {
 			for _, topic := range project.Topics {
-				// Use strings.Contains to allow partial matches
 				if strings.Contains(strings.ToLower(topic), term) {
 					anyTermMatches = true
 					break
 				}
 			}
+			if !anyTermMatches && strings.Contains(strings.ToLower(project.Repo), term) {
+				anyTermMatches = true
+			}
+			if !anyTermMatches {
+				for _, alias := range project.Aliases {
+					if strings.Contains(strings.ToLower(alias), term) {
+						anyTermMatches = true
+						break
+					}
+				}
+			}
 			if anyTermMatches {
-				break // Found a match, no need to check other terms
+				break
 			}
 		}
 
@@ -336,10 +346,24 @@ func (m projectSelectorModel) applyAllFilters() []config.Project {
 		for _, term := range allTerms {
 			termLower := strings.ToLower(term)
 			termMatches := false
+			// Match against topics
 			for _, topic := range project.Topics {
 				if strings.Contains(strings.ToLower(topic), termLower) {
 					termMatches = true
 					break
+				}
+			}
+			// Match against repo name
+			if !termMatches && strings.Contains(strings.ToLower(project.Repo), termLower) {
+				termMatches = true
+			}
+			// Match against aliases
+			if !termMatches {
+				for _, alias := range project.Aliases {
+					if strings.Contains(strings.ToLower(alias), termLower) {
+						termMatches = true
+						break
+					}
 				}
 			}
 			if !termMatches {


### PR DESCRIPTION
Add aliases field to Project config so repos can be found by alternative names (e.g., merchant-account → merchant-account-service). Normalize .git suffix on load to prevent double-suffix clone URL bugs. Extend filter matching to search repo names and aliases, not just topics. Add FindProjectByNameOrAlias resolver with Levenshtein-based suggestions.